### PR TITLE
Align card-type options to the right

### DIFF
--- a/src/lib/components/subreddit/Cards.svelte
+++ b/src/lib/components/subreddit/Cards.svelte
@@ -20,5 +20,5 @@
 </script>
 
 <div class="text-sm sm:text-base">
-	<Select options={card_options} values={card_values} on:select={select_card} />
+	<Select options={card_options} values={card_values} on:select={select_card} align="right"/>
 </div>

--- a/src/lib/components/utils/Select.svelte
+++ b/src/lib/components/utils/Select.svelte
@@ -3,6 +3,7 @@
 	export let values: string[] | number[] = options;
 	export let id = 0;
 	export let accent: string = 'text-blue-500';
+	export let align = "left"
 
 	import Expand from '../icons/Expand.svelte';
 
@@ -39,7 +40,7 @@
 		<Expand size={5} color={toggle % 2 === 1 ? accent : 'text-black'} />
 	</button>
 	<div class="relative" class:hidden={toggle % 2 === 0}>
-		<ul class="absolute z-50 rounded bg-white shadow">
+		<ul class="absolute z-50 rounded bg-white shadow" class:right-0={align === "right"}>
 			{#each options as option, i}
 				<li on:click={() => select(i)}>{option}</li>
 			{/each}


### PR DESCRIPTION
### Description

Added an option to utils/Select.svelte to align the options box to the right, and aligned the options to the right for card-type select.

### Issues

- #10 