### PR TITLE
Resize album if media data exist

### DIFF
--- a/src/lib/components/utils/Slideshow.svelte
+++ b/src/lib/components/utils/Slideshow.svelte
@@ -30,6 +30,7 @@
 				size: calculateImageSize(val.s.x, val.s.y, max_w, max_h)
 			};
 		});
+		if (images.length < 1) return
 		box_height = images
 			.map((val) => val.size.height)
 			.reduce((a, b) => {


### PR DESCRIPTION
### Description

Resize album only if media data exists. Currently returns an error and make the website unresponsive if it doesn't exist.

### Issues

- #36 